### PR TITLE
Add arcpy Warnings

### DIFF
--- a/GetStarted/popup_create_c_sub.py
+++ b/GetStarted/popup_create_c_sub.py
@@ -103,6 +103,9 @@ class CreateSubCondition(object):
                 fGl.open_folder(self.dir2sub_condition)
                 self.b_create_c.config(fg="forest green", text="Sub-Condition created.")
                 self.l_run_info.config(text="New condition: %s" % self.dir2sub_condition)
+                if str(self.dir2bound).endswith("shp"):
+                    msg = "Restart River Architect to create ANOTHER SUBSET (arcpy issue)"
+                    self.b_create_c.config(text=msg, fg="MediumOrchid4")
             else:
                 self.b_create_c.config(fg="red", text="Sub-Condition creation failed (click to re-run).")
         except:

--- a/GetStarted/welcome_gui.py
+++ b/GetStarted/welcome_gui.py
@@ -103,6 +103,7 @@ class MainGui(sg.RaModuleGui):
         self.b_make_inp["state"] = "disabled"
         self.master.wait_window(new_window.top)
         self.b_make_inp["state"] = "normal"
+        del new_window
 
     def populate_c(self):
         try:

--- a/SHArC/cHSI.py
+++ b/SHArC/cHSI.py
@@ -508,6 +508,11 @@ class HHSI:
         i_hsi_prev = curve_data[1][0]
         for i_par in curve_data[0]:
             try:
+                float(i_par)
+            except:
+                self.logger.info("      * skipping all values larger than {0} (no data provided).".format(str(i_par_prev)))
+                break
+            try:
                 __ras__.append(Float(Con((Float(ras) >= Float(i_par_prev)) & (Float(ras) < Float(i_par)), (
                                          Float(i_hsi_prev) + (
                                           (Float(ras) - Float(i_par_prev)) / (Float(i_par) - Float(i_par_prev)) * Float(

--- a/SHArC/sub_gui_hhsi.py
+++ b/SHArC/sub_gui_hhsi.py
@@ -142,6 +142,7 @@ class HHSIgui(object):
         self.b_Q.config(fg="black", text="View discharge dependency file (xlsx workbook)",
                         command=lambda: self.open_files(self.discharge_xlsx), bg="PaleGreen1")
         self.b_run["state"] = "normal"
+        self.b_run.config(fg="MediumOrchid4")
 
     def run_raster_calc(self):
         msg0 = "Analysis takes a while. \nPython windows seem unresponsive in the meanwhile. \nCheck console messages."
@@ -156,7 +157,7 @@ class HHSIgui(object):
             if not hhsi.error:
                 fG.open_folder(hhsi.path_hsi)
                 self.l_run_info.config(fg="forest green", text="RUN SUCCESSFULLY COMPLETED (close window)")
-                self.b_run.config(width=30, bg="PaleGreen1", text="Re-run (generate habitat condition)")
+                self.b_run.config(width=30, fg="dark green", bg="PaleGreen1", text="Re-run (generate habitat condition)")
             else:
                 self.l_run_info.config(fg="red", text="RUN COMPLETED WITH ERRORS")
                 self.b_run.config(bg="salmon", text="Re-run (generate habitat condition)")


### PR DESCRIPTION
## Description
Sub-condition creation linked with habitat statistics requires restarting River Architect because of an issue with `arcpy`.

## Related Issue
`arcpy` will not register feature classes unless River Architect is restarted:
[`arcpy ERROR 130051: Input feature class is not registered as versioned.`](http://desktop.arcgis.com/en/arcmap/latest/manage-data/geodatabases/registering-data-as-versioned.htm)

Thus, providing a boundary shapefile (feature class) rather than a GeoTIFF (Raster class) will cause incoherent condition geodata. The issue cannot be trouble-shot for now and restarting River Architect after creating a subet-*Condition* remains the only remedy available. According hints are now implemented in the updated files.

## Motivation and Context
This issue will be another motivation to abandon `arcpy` ...

## How Has This Been Tested?
LYR data.

